### PR TITLE
Fix OnPrem Data Maintenance Scripts

### DIFF
--- a/Scripts/SQLServer/DataTrimmingScripts/Delete_Insights_Data_DBO.sql
+++ b/Scripts/SQLServer/DataTrimmingScripts/Delete_Insights_Data_DBO.sql
@@ -18,6 +18,11 @@ CREATE OR ALTER PROCEDURE [dbo].[Delete_Insights_Data_DBO]
 	@BatchSize INT = 100000
 AS
 BEGIN
+	IF IS_SRVROLEMEMBER('sysadmin') != 1
+	BEGIN
+		PRINT('Failed to execute the script! Current user doesn''t own sysadmin role.')
+    	RETURN;
+	END;
 
 	DECLARE @total_deleted_jobEvents BIGINT = 0;
 	DECLARE @total_deleted_queueItemEvents BIGINT = 0;

--- a/Scripts/SQLServer/DataTrimmingScripts/Delete_Insights_Data_Read.sql
+++ b/Scripts/SQLServer/DataTrimmingScripts/Delete_Insights_Data_Read.sql
@@ -8,60 +8,91 @@ GO
 CREATE OR ALTER PROCEDURE [read].[Delete_Insights_Data_Read]
 AS
 BEGIN
+	IF IS_SRVROLEMEMBER('sysadmin') != 1
+	BEGIN
+		PRINT('Failed to execute the script! Current user doesn''t own sysadmin role.')
+    	RETURN;
+	END;
 
-	-- clear read data
-	TRUNCATE TABLE [read].[Jobs];
-	TRUNCATE TABLE [read].[JobEvents];
-	TRUNCATE TABLE [read].[QueueItems];
-	TRUNCATE TABLE [read].[QueueItemEvents];
-	TRUNCATE TABLE [read].[RobotLogs];
+	-- rename all read tables
+	IF EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'read' AND TABLE_NAME = 'Jobs')
+	BEGIN
+	exec sp_rename 'read.Jobs', 'Jobs_Temp';
+	END;
 
-	-- rebuild all Dynamic Json tables
-	UPDATE [read].[JsonSettings]
-	SET DdlOperationPerformed = 0, LastUpdatedTime = GETUTCDATE()
-	WHERE Enabled = 1;
+	IF EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'read' AND TABLE_NAME = 'JobEvents')
+	BEGIN
+	exec sp_rename 'read.JobEvents', 'JobEvents_Temp';
+	END;
+
+	IF EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'read' AND TABLE_NAME = 'QueueItems')
+	BEGIN
+	exec sp_rename 'read.QueueItems', 'QueueItems_Temp';
+	END;
+
+	IF EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'read' AND TABLE_NAME = 'QueueItemEvents')
+	BEGIN
+	exec sp_rename 'read.QueueItemEvents', 'QueueItemEvents_Temp';
+	END;
+
+	IF EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'read' AND TABLE_NAME = 'RobotLogs')
+	BEGIN
+	exec sp_rename 'read.RobotLogs', 'RobotLogs_Temp';
+	END;
 
 	-- kill all of running Migrate Data SPs
 	DECLARE @command NVARCHAR(MAX);
 
 	WHILE EXISTS (SELECT session_id 
 			  FROM sys.dm_exec_requests handle OUTER APPLY sys.fn_get_sql(handle.sql_handle) spname  
-			  WHERE spname.text LIKE '%Migrate%' AND spname.text NOT LIKE '%sys.dm_exec_requests%')
+			  WHERE (spname.text LIKE '%MigrateJobs%' OR spname.text LIKE '%MigrateQueueItems%' OR spname.text LIKE '%MigrateRobotLogs%')
+			  AND spname.text NOT LIKE '%sys.dm_exec_requests%')
     BEGIN
 		SELECT @command = STRING_AGG(CONCAT ('KILL ', session_id), ' ')  
 		FROM sys.dm_exec_requests handle OUTER APPLY sys.fn_get_sql(handle.sql_handle) spname  
-		WHERE spname.text LIKE '%Migrate%' AND spname.text NOT LIKE '%sys.dm_exec_requests%';
+		WHERE (spname.text LIKE '%MigrateJobs%' OR spname.text LIKE '%MigrateQueueItems%' OR spname.text LIKE '%MigrateRobotLogs%')
+		AND spname.text NOT LIKE '%sys.dm_exec_requests%';
 
     	EXEC (@command);
 	-- Aborted SP will be retried, wait 3 seconds and kill the process again. 
 		WAITFOR DELAY '00:00:03';
     END;
 
-	-- Verify again, if there is data in the table again, truncate the table again.
-	IF EXISTS (SELECT TOP 1 * FROM [read].[RobotLogs]) 
+	-- truncate all temp tables and change the tables to their original names
+	IF EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'read' AND TABLE_NAME = 'Jobs_Temp')
 	BEGIN
-    	TRUNCATE TABLE [read].[RobotLogs];
+	TRUNCATE TABLE [read].[Jobs_Temp];
+	exec sp_rename 'read.Jobs_Temp', 'Jobs';
 	END;
 
-	IF EXISTS (SELECT TOP 1 * FROM [read].[Jobs]) 
+	IF EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'read' AND TABLE_NAME = 'JobEvents_Temp')
 	BEGIN
-    	TRUNCATE TABLE [read].[Jobs];
+	TRUNCATE TABLE [read].[JobEvents_Temp];
+	exec sp_rename 'read.JobEvents_Temp', 'JobEvents';
 	END;
 
-	IF EXISTS (SELECT TOP 1 * FROM [read].[JobEvents]) 
+	IF EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'read' AND TABLE_NAME = 'QueueItems_Temp')
 	BEGIN
-    	TRUNCATE TABLE [read].[JobEvents];
+	TRUNCATE TABLE [read].[QueueItems_Temp];
+	exec sp_rename 'read.QueueItems_Temp', 'QueueItems';
 	END;
 
-	IF EXISTS (SELECT TOP 1 * FROM [read].[QueueItems]) 
+	IF EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'read' AND TABLE_NAME = 'QueueItemEvents_Temp')
 	BEGIN
-    	TRUNCATE TABLE [read].[QueueItems];
+	TRUNCATE TABLE [read].[QueueItemEvents_Temp];
+	exec sp_rename 'read.QueueItemEvents_Temp', 'QueueItemEvents';
 	END;
 
-	IF EXISTS (SELECT TOP 1 * FROM [read].[QueueItemEvents]) 
+	IF EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'read' AND TABLE_NAME = 'RobotLogs_Temp')
 	BEGIN
-    	TRUNCATE TABLE [read].[QueueItemEvents];
+	TRUNCATE TABLE [read].[RobotLogs_Temp];
+	exec sp_rename 'read.RobotLogs_Temp', 'RobotLogs';
 	END;
+
+	-- rebuild all Dynamic Json tables
+	UPDATE [read].[JsonSettings]
+	SET DdlOperationPerformed = 0, LastUpdatedTime = GETUTCDATE()
+	WHERE Enabled = 1;
 
     PRINT('The script executed successfully!');
 

--- a/Scripts/SQLServer/DataTrimmingScripts/Delete_Insights_Data_Read.sql
+++ b/Scripts/SQLServer/DataTrimmingScripts/Delete_Insights_Data_Read.sql
@@ -19,7 +19,49 @@ BEGIN
 	-- rebuild all Dynamic Json tables
 	UPDATE [read].[JsonSettings]
 	SET DdlOperationPerformed = 0, LastUpdatedTime = GETUTCDATE()
-	WHERE Enabled = 1
+	WHERE Enabled = 1;
+
+	-- kill all of running Migrate Data SPs
+	DECLARE @command NVARCHAR(MAX);
+
+	WHILE EXISTS (SELECT session_id 
+			  FROM sys.dm_exec_requests handle OUTER APPLY sys.fn_get_sql(handle.sql_handle) spname  
+			  WHERE spname.text LIKE '%Migrate%' AND spname.text NOT LIKE '%sys.dm_exec_requests%')
+    BEGIN
+		SELECT @command = STRING_AGG(CONCAT ('KILL ', session_id), ' ')  
+		FROM sys.dm_exec_requests handle OUTER APPLY sys.fn_get_sql(handle.sql_handle) spname  
+		WHERE spname.text LIKE '%Migrate%' AND spname.text NOT LIKE '%sys.dm_exec_requests%';
+
+    	EXEC (@command);
+	-- Aborted SP will be retried, wait 3 seconds and kill the process again. 
+		WAITFOR DELAY '00:00:03';
+    END;
+
+	-- Verify again, if there is data in the table again, truncate the table again.
+	IF EXISTS (SELECT TOP 1 * FROM [read].[RobotLogs]) 
+	BEGIN
+    	TRUNCATE TABLE [read].[RobotLogs];
+	END;
+
+	IF EXISTS (SELECT TOP 1 * FROM [read].[Jobs]) 
+	BEGIN
+    	TRUNCATE TABLE [read].[Jobs];
+	END;
+
+	IF EXISTS (SELECT TOP 1 * FROM [read].[JobEvents]) 
+	BEGIN
+    	TRUNCATE TABLE [read].[JobEvents];
+	END;
+
+	IF EXISTS (SELECT TOP 1 * FROM [read].[QueueItems]) 
+	BEGIN
+    	TRUNCATE TABLE [read].[QueueItems];
+	END;
+
+	IF EXISTS (SELECT TOP 1 * FROM [read].[QueueItemEvents]) 
+	BEGIN
+    	TRUNCATE TABLE [read].[QueueItemEvents];
+	END;
 
     PRINT('The script executed successfully!');
 

--- a/Scripts/SQLServer/DataTrimmingScripts/Delete_Process_Logs_DBO.sql
+++ b/Scripts/SQLServer/DataTrimmingScripts/Delete_Process_Logs_DBO.sql
@@ -10,6 +10,12 @@ CREATE OR ALTER PROCEDURE [dbo].[Delete_Process_Logs_DBO]
 	@BatchSize INT = 100000
 AS
 BEGIN
+	IF IS_SRVROLEMEMBER('sysadmin') != 1
+	BEGIN
+		PRINT('Failed to execute the script! Current user doesn''t own sysadmin role.')
+    	RETURN;
+	END;
+
 	SET NOCOUNT ON;
 	DECLARE @Start_RobotLogs_Cutoff_Id BIGINT = 0;
 	DECLARE @End_RobotLogs_Cutoff_Id BIGINT = 0;

--- a/Scripts/SQLServer/DataTrimmingScripts/Delete_Process_Logs_Read.sql
+++ b/Scripts/SQLServer/DataTrimmingScripts/Delete_Process_Logs_Read.sql
@@ -36,6 +36,28 @@ BEGIN
 	SET DdlOperationPerformed = 0, LastUpdatedTime = GETUTCDATE()
 	WHERE QueueJsonType IS NULL AND ObjectName = @ProcessName AND Enabled = 1 AND TenantKey = @TenantKey;
 
+	-- kill all of running Migrate RobotLogs SPs
+	DECLARE @command NVARCHAR(MAX);
+
+	WHILE EXISTS (SELECT session_id 
+			  FROM sys.dm_exec_requests handle OUTER APPLY sys.fn_get_sql(handle.sql_handle) spname  
+			  WHERE spname.text LIKE '%MigrateRobotLogs%' AND spname.text NOT LIKE '%sys.dm_exec_requests%')
+    BEGIN
+		SELECT @command = STRING_AGG(CONCAT ('KILL ', session_id), ' ')  
+		FROM sys.dm_exec_requests handle OUTER APPLY sys.fn_get_sql(handle.sql_handle) spname  
+		WHERE spname.text LIKE '%MigrateRobotLogs%' AND spname.text NOT LIKE '%sys.dm_exec_requests%';
+
+    	EXEC (@command);
+	-- Aborted SP will be retried, wait 3 seconds and kill the process again. 
+		WAITFOR DELAY '00:00:03';
+    END;
+
+	-- Verify again, if there is data in the table again, truncate the table again. 
+	IF EXISTS (SELECT TOP 1 * FROM [read].[RobotLogs]) 
+	BEGIN
+    	TRUNCATE TABLE [read].[RobotLogs];
+	END;
+
     PRINT('The script executed successfully!');
 
 END;

--- a/Scripts/SQLServer/DeleteByTenantKey/DeleteByTenantKey.sql
+++ b/Scripts/SQLServer/DeleteByTenantKey/DeleteByTenantKey.sql
@@ -1,19 +1,96 @@
-DECLARE @tenantKey VARCHAR(128);
-DECLARE @tenantId int;
-SET @tenantKey = '123e4567-e89b-12d3-a456-426652340000'; --replace with tenantKey from dbo.tenants
-SET @tenantId = (select id from [dbo].[Tenants] where [key] = @tenantKey);
+IF IS_SRVROLEMEMBER('sysadmin') = 1
+BEGIN
+    DECLARE @tenantKey VARCHAR(128);
+    DECLARE @tenantId int;
+    SET @tenantKey = '123e4567-e89b-12d3-a456-426652340000'; --replace with tenantKey from dbo.tenants
+    SET @tenantId = (select id from [dbo].[Tenants] where [key] = @tenantKey);
 
-delete from [dbo].[JobEvents] where TenantKey = @tenantKey;
-delete from [dbo].[Jobs] where TenantKey = @tenantKey;
-delete from [dbo].[QueueItemEvents] where TenantKey = @tenantKey;
-delete from [dbo].[QueueItems] where TenantKey = @tenantKey;
-delete from [dbo].[RobotLogs] where TenantId = @tenantId;
-delete from [read].[QueueDynamicJsonMetadata] where TenantKey = @tenantKey;
-delete from [read].[RobotDynamicJsonMetadata] where TenantKey = @tenantKey;
+    delete from [dbo].[JobEvents] where TenantKey = @tenantKey;
+    delete from [dbo].[Jobs] where TenantKey = @tenantKey;
+    delete from [dbo].[QueueItemEvents] where TenantKey = @tenantKey;
+    delete from [dbo].[QueueItems] where TenantKey = @tenantKey;
+    delete from [dbo].[RobotLogs] where TenantId = @tenantId;
+    delete from [read].[QueueDynamicJsonMetadata] where TenantKey = @tenantKey;
+    delete from [read].[RobotDynamicJsonMetadata] where TenantKey = @tenantKey;
 
---if you have mulitple deleted tenant, you just need to truncate read tables once
-truncate table [read].[RobotLogs];
-truncate table [read].[Jobs];
-truncate table [read].[JobEvents];
-truncate table [read].[QueueItems];
-truncate table [read].[QueueItemEvents];
+    -- rename all read tables
+	IF EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'read' AND TABLE_NAME = 'Jobs')
+	BEGIN
+	exec sp_rename 'read.Jobs', 'Jobs_Temp';
+	END;
+
+	IF EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'read' AND TABLE_NAME = 'JobEvents')
+	BEGIN
+	exec sp_rename 'read.JobEvents', 'JobEvents_Temp';
+	END;
+
+	IF EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'read' AND TABLE_NAME = 'QueueItems')
+	BEGIN
+	exec sp_rename 'read.QueueItems', 'QueueItems_Temp';
+	END;
+
+	IF EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'read' AND TABLE_NAME = 'QueueItemEvents')
+	BEGIN
+	exec sp_rename 'read.QueueItemEvents', 'QueueItemEvents_Temp';
+	END;
+
+	IF EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'read' AND TABLE_NAME = 'RobotLogs')
+	BEGIN
+	exec sp_rename 'read.RobotLogs', 'RobotLogs_Temp';
+	END;
+
+    -- kill all of running Migrate Data SPs
+	DECLARE @command NVARCHAR(MAX);
+
+	WHILE EXISTS (SELECT session_id 
+			  FROM sys.dm_exec_requests handle OUTER APPLY sys.fn_get_sql(handle.sql_handle) spname  
+			  WHERE (spname.text LIKE '%MigrateJobs%' OR spname.text LIKE '%MigrateQueueItems%' OR spname.text LIKE '%MigrateRobotLogs%')
+			  AND spname.text NOT LIKE '%sys.dm_exec_requests%')
+    BEGIN
+		SELECT @command = STRING_AGG(CONCAT ('KILL ', session_id), ' ')  
+		FROM sys.dm_exec_requests handle OUTER APPLY sys.fn_get_sql(handle.sql_handle) spname  
+		WHERE (spname.text LIKE '%MigrateJobs%' OR spname.text LIKE '%MigrateQueueItems%' OR spname.text LIKE '%MigrateRobotLogs%')
+		AND spname.text NOT LIKE '%sys.dm_exec_requests%';
+
+    	EXEC (@command);
+	-- Aborted SP will be retried, wait 3 seconds and kill the process again. 
+		WAITFOR DELAY '00:00:03';
+    END;
+
+    -- truncate all temp tables and change the tables to their original names
+	IF EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'read' AND TABLE_NAME = 'Jobs_Temp')
+	BEGIN
+	TRUNCATE TABLE [read].[Jobs_Temp];
+	exec sp_rename 'read.Jobs_Temp', 'Jobs';
+	END;
+
+	IF EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'read' AND TABLE_NAME = 'JobEvents_Temp')
+	BEGIN
+	TRUNCATE TABLE [read].[JobEvents_Temp];
+	exec sp_rename 'read.JobEvents_Temp', 'JobEvents';
+	END;
+
+	IF EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'read' AND TABLE_NAME = 'QueueItems_Temp')
+	BEGIN
+	TRUNCATE TABLE [read].[QueueItems_Temp];
+	exec sp_rename 'read.QueueItems_Temp', 'QueueItems';
+	END;
+
+	IF EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'read' AND TABLE_NAME = 'QueueItemEvents_Temp')
+	BEGIN
+	TRUNCATE TABLE [read].[QueueItemEvents_Temp];
+	exec sp_rename 'read.QueueItemEvents_Temp', 'QueueItemEvents';
+	END;
+
+	IF EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'read' AND TABLE_NAME = 'RobotLogs_Temp')
+	BEGIN
+	TRUNCATE TABLE [read].[RobotLogs_Temp];
+	exec sp_rename 'read.RobotLogs_Temp', 'RobotLogs';
+	END;
+
+    PRINT('The script executed successfully!');
+END;
+ELSE
+BEGIN
+    PRINT('Failed to execute the script! Current user doesn''t own sysadmin role.')
+END;


### PR DESCRIPTION
**Why fixt this?**
Our ETLs logic:  First 1. get the max(read_id) and max(staging_id) then determine a bound [max(read_id), max(staging_id)], then 2. use this bound to transfer data from staging tables to read tables.

Race condition: If 1. ETL get the bound mentioned above, 2. Right after, the maintenance scripts truncate the read tables. 3. ETL insert the data [max(read_id), max(staging_id)] into truncated table which will cause the latest data insert into read tables, then the old data will not be transferred by ETL. 


**How this change could fix this?**

1. After we rename and kill all existing processes related to ETL, we could always guarantee that the following requests will run with exceptions because the original tables' names changed. After we truncate the temp tables and change the name back to original ones, we could guarantee all the following processes will start from select bound step, so the above race condition wouldn't exist.
2. I tried to drop+create new read tables, but eventually not use that strategy because it make us hard to maintain this script since we need to make sure that new-created tables have the exactly same structure as the original ones (including indexes, schema, etc...), so I think rename + truncate + rename back is the easiest way to do this.


**Testings have done:**

**a) Positive test:**
1. Log in user with the role `sysadmin` only
2. Generate the race condition manually with the help of command https://learn.microsoft.com/en-us/sql/t-sql/language-elements/waitfor-transact-sql?view=sql-server-ver16 and tested the new scripts, see all the data gone and re-ingested by Orchestrator background job again. 

**b) Negative test:**
Use user without `sysadmin`, and none of scripts could be run 

**c) Why we need `sysadmin` role?**
We need to find all the existing running processes and kill them to avoid other race conditions, basically similar to what I mentioned above. 

